### PR TITLE
Change lifecycle

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const uglifier = require('./lib/uglifier');
 
 function FasterUglifyPlugin(options) {
@@ -6,12 +5,12 @@ function FasterUglifyPlugin(options) {
 }
 
 FasterUglifyPlugin.prototype.apply = function apply(compiler) {
-  compiler.plugin('done', stats => {
-    const outputFiles = Object.keys(stats.compilation.assets);
-    const filePaths = outputFiles.map(outputFile => (
-      path.join(stats.compilation.outputOptions.path, outputFile)
-    ));
-    uglifier.processFiles(filePaths, this.options);
+  compiler.plugin('compilation', compilation => {
+    compilation.plugin('optimize-chunk-assets', (chunks, callback) => {
+      uglifier.processAssets(compilation.assets, this.options).then(() => {
+        callback();
+      });
+    });
   });
 };
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,14 +1,12 @@
 const crypto = require('crypto');
-const fs = require('fs');
 
 // Small helper function to quickly create a hash from any given string.
-function createHashFrom(content) {
+function createHashFromContent(content) {
   const hash = crypto.createHash('sha256');
   hash.update(content);
   return hash.digest('hex');
 }
 
-module.exports = function cacheSignatureGenerator(absFile) {
-  const fileContent = fs.readFileSync(absFile, 'utf-8');
-  return createHashFrom(fileContent);
+module.exports = {
+  createHashFromContent,
 };

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -2,20 +2,11 @@
 
 const os = require('os');
 const path = require('path');
-const fs = require('fs');
 const mkdirp = require('mkdirp');
 const childProcess = require('child_process');
-const cacheKeyGenerator = require('./cache');
-
-function copyFile(sourceFile, destinationFile) {
-  try {
-    mkdirp(path.dirname(destinationFile));
-    fs.writeFileSync(destinationFile, fs.readFileSync(sourceFile, 'utf-8'));
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
+const RawSource = require('webpack-sources').RawSource;
+const cache = require('./cache');
+const fs = require('fs');
 
 function createWorkers(count) {
   const workers = [];
@@ -27,65 +18,103 @@ function createWorkers(count) {
   return workers;
 }
 
+/**
+ * Determines how many workers to create.
+ * Should be available cpus minus 1.
+ */
 function workerCount() {
   return Math.max(1, os.cpus().length - 1);
 }
 
-function minify(file, worker, options) {
-  const cacheKey = cacheKeyGenerator(file);
+/**
+ * Create a cache key from both the source, and the options used to minify the file.
+ */
+function createCacheKey(source, options) {
+  return cache.createHashFromContent(source + JSON.stringify(options));
+}
+
+/**
+ * Attempt to read from cache. If the read fails, or cacheDir isn't defined return null.
+ */
+function retrieveFromCache(cacheKey, cacheDir) {
+  if (cacheDir) {
+    try {
+      return fs.readFileSync(path.join(cacheDir, `${cacheKey}.js`), 'utf8');
+    } catch (e) { void(0); } // this just means it is uncached.
+  }
+  return null;
+}
+
+/**
+ * Attempt to write the file to the cache.
+ */
+function saveToCache(cacheKey, minifiedCode, cacheDir) {
+  if (cacheDir) {
+    fs.writeFileSync(path.join(cacheDir, `${cacheKey}.js`), minifiedCode);
+  }
+}
+
+/**
+ * Minify an asset.  This attempts to read from the cache first, but if a cached version isn't found
+ * it sends a request to the worker to minify.  It may make more sense for the worker to handle
+ * the cache, but sending the full source over ipc is expensive. Reading from disk is much faster.
+ */
+function minify(assetName, asset, worker, options) {
+  const assetContents = asset.source();
+  const cacheKey = createCacheKey(assetContents, options);
   return new Promise((resolve, reject) => {
-    worker.send({
-      type: 'minify',
-      options,
-      file,
-    });
-    worker.on('message', msg => {
-      if (msg.file === file) {
-        if (msg.type === 'success') {
-          if (options.cacheDir) {
-            copyFile(file, path.join(options.cacheDir, `${cacheKey}.js`));
+    const cachedContent = retrieveFromCache(cacheKey, options.cacheDir);
+
+    if (cachedContent) {
+      resolve(cachedContent);
+    } else {
+      worker.send({
+        type: 'minify',
+        options,
+        assetContents,
+        assetName,
+      });
+
+      worker.on('message', msg => {
+        if (msg.assetName === assetName) {
+          if (msg.type === 'success') {
+            const minifiedCode = msg.newContent;
+            saveToCache(cacheKey, minifiedCode, options.cacheDir);
+            resolve(minifiedCode);
+          } else {
+            reject();
           }
-          resolve();
-        } else {
-          reject();
         }
-      }
-    });
+      });
+    }
   });
 }
 
-function copyFromCache(absFile, cacheDir) {
-  const cacheKey = cacheKeyGenerator(absFile);
-  const cachedFile = path.join(cacheDir, `${cacheKey}.js`);
-  return copyFile(cachedFile, absFile);
-}
-
-function processFiles(files, options) {
-  // const cacheMap = loadCacheMap(options.cacheDir);
+function processAssets(assetHash, options) {
   const workers = createWorkers(workerCount());
-  let filesToMinify = files;
   if (options.cacheDir) {
-    filesToMinify = files.filter(absPath => {
-      // returns true if cached and copied, false otherwise.
-      const successfullyCopied = copyFromCache(absPath, options.cacheDir);
-      return !successfullyCopied;
-    });
+    mkdirp(options.cacheDir);
   }
 
-  const promises = filesToMinify.map((absPath, index) => {
+  const promises = Object.keys(assetHash).map((assetName, index) => {
+    const asset = assetHash[assetName];
     const worker = workers[index % workers.length];
-    return minify(absPath, worker, options);
+    return minify(assetName, asset, worker, options).then(msgContent => {
+      assetHash[assetName] = new RawSource(msgContent); // eslint-disable-line no-param-reassign
+    });
   });
-  Promise.all(promises).then(() => {
+
+  return Promise.all(promises).then(() => {
     workers.forEach(worker => worker.kill()); // workers are done, kill them.
   });
 }
 
 module.exports = {
-  processFiles,
-  copyFromCache,
-  minify,
+  processAssets,
   workerCount,
   createWorkers,
-  copyFile,
+  createCacheKey,
+  retrieveFromCache,
+  saveToCache,
+  minify,
 };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,16 +1,19 @@
 const uglify = require('uglify-js');
-const fs = require('fs');
+
+function minify(source, uglifyOptions) {
+  const opts = Object.assign({}, uglifyOptions, { fromString: true });
+  return uglify.minify(source, opts).code;
+}
 
 function messageHandler(msg) {
   if (msg.type === 'minify') {
-    const file = msg.file;
-    const fileContents = fs.readFileSync(file, 'utf-8');
-    const options = Object.assign({}, msg.options.uglifyJS, { fromString: true });
-    const results = uglify.minify(fileContents, options);
-    fs.writeFileSync(msg.file, results.code);
+    const assetName = msg.assetName;
+    const newContent = minify(msg.assetContents, msg.options.uglifyJS);
+
     process.send({
-      file,
       type: 'success',
+      newContent,
+      assetName,
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "uglify-js": "^2.6.2"
+    "uglify-js": "^2.6.2",
+    "webpack-sources": "^0.1.2"
   }
 }

--- a/test/lib/cache.js
+++ b/test/lib/cache.js
@@ -1,9 +1,8 @@
-import cacheKeyGenerator from '../../lib/cache';
-import path from 'path';
+import cache from '../../lib/cache';
 import test from 'ava';
 
 test('cacheKeyGenerator should return a sha256 hash for a given file name', t => {
-  const result = cacheKeyGenerator(path.join(__dirname, 'cache.js'));
+  const result = cache.createHashFromContent('asdf');
   t.is(typeof result, 'string');
   t.is(result.length, 64);
 });

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -4,26 +4,24 @@ import fs from 'fs';
 import os from 'os';
 import childProcess from 'child_process';
 import path from 'path';
-import cacheKeyGenerator from '../../lib/cache';
 
 const stubbedOn = sinon.stub(process, 'on');
 const {
-  copyFromCache,
+  retrieveFromCache,
   minify,
   workerCount,
   createWorkers,
-  copyFile,
 } = require('../../lib/uglifier');
+
 stubbedOn.restore();
 
 let stubbedRead;
-let stubbedWrite;
 test.beforeEach(() => {
-  stubbedRead = sinon.stub(fs, 'readFileSync', (fileName) => {
+  stubbedRead = sinon.stub(fs, 'readFileSync', (filePath) => {
+    const fileName = path.basename(filePath, '.js');
     if (fileName === 'throw') throw new Error('error');
     return 'filecontents';
   });
-  stubbedWrite = sinon.stub(fs, 'writeFileSync');
 });
 
 const fakeWorker = {
@@ -34,18 +32,6 @@ const fakeWorker = {
 
 test.afterEach(() => {
   stubbedRead.restore();
-  stubbedWrite.restore();
-});
-
-test('copyFile should copy contents from source file into destination file and return true', t => {
-  const result = copyFile('source', 'dest');
-  t.true(stubbedWrite.calledWith('dest', 'filecontents'));
-  t.true(result);
-});
-
-test('copyFile should return false if it fails to copy.', t => {
-  const result = copyFile('throw', 'dest');
-  t.false(result);
 });
 
 test('workerCount should be cpus - 1', t => {
@@ -62,16 +48,23 @@ test('createWorkers should fork x times', t => {
 });
 
 test('minify should return a Promise', t => {
-  const promise = minify(path.join(__dirname, 'uglifier.js'), fakeWorker, {});
+  const promise = minify('uglifier.js', { source: () => 'asdf;' }, fakeWorker, {});
   // ava uses babel for tests so Promise probably isn't node Promise.
   t.is(typeof promise.then, 'function');
 });
 
-test('copyFromCache should attempt to copy a file from cache', t => {
+test('retrieveFromCache should return cached content', t => {
   const cacheDir = '/dev/null';
-  const fileName = 'test';
-  copyFromCache(fileName, cacheDir);
-  const cachedFile = path.join(cacheDir, `${cacheKeyGenerator('test')}.js`);
+  const cacheKey = 'test';
+  const result = retrieveFromCache(cacheKey, cacheDir);
+  const cachedFile = path.join(cacheDir, `${cacheKey}.js`);
   t.true(stubbedRead.calledWith(cachedFile));
-  t.true(stubbedWrite.calledWith(fileName, 'filecontents'));
+  t.is(result, 'filecontents');
+});
+
+test('retrieveFromCache should return a falsy value if the cache file does not exist', t => {
+  const cacheDir = '/dev/null';
+  const cacheKey = 'throw';
+  const result = retrieveFromCache(cacheKey, cacheDir);
+  t.falsy(result);
 });

--- a/test/lib/worker.js
+++ b/test/lib/worker.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import fs from 'fs';
+import uglify from 'uglify-js';
 import sinon from 'sinon';
 
 // ava is multi process and uses process.on,
@@ -9,26 +9,24 @@ const messageHandler = require('../../lib/worker');
 stubbedOn.restore();
 
 test('messageHandler should handle minify messages, minifying the provided file.', t => {
-  const stubbedRead = sinon.stub(fs, 'readFileSync', () => 'function    test()    {}');
-  const stubbedWrite = sinon.stub(fs, 'writeFileSync');
   const stubbedSend = sinon.stub(process, 'send');
-  const file = 'abc';
+  const assetName = 'abc';
+  const originalContent = 'function  test   ()    {   void(0); }';
   messageHandler({
     type: 'minify',
-    file,
+    assetName,
+    assetContents: originalContent,
     options: {
       uglifyJS: {
         bunk: true,
       },
     },
   });
-  t.true(stubbedRead.calledWith(file));
-  t.true(stubbedWrite.calledWith(file, 'function test(){}'));
+
   t.true(stubbedSend.calledWith({
     type: 'success',
-    file,
+    assetName,
+    newContent: uglify.minify(originalContent, { fromString: true }).code,
   }));
   stubbedSend.restore();
-  stubbedRead.restore();
-  stubbedWrite.restore();
 });


### PR DESCRIPTION
This switch comes for two reasons. The first is that optimize-chunk-assets is
the correct place to do minification, it's what the lifecycle event is for.
The other reason is that done doesn't take a callback, so callbacks provided to
compiler.run, were being called at the wrong time.