### PR TITLE
Add prune function to prevent unbounded cache growth.

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -7,6 +7,8 @@ const childProcess = require('child_process');
 const RawSource = require('webpack-sources').RawSource;
 const cache = require('./cache');
 const fs = require('fs');
+const glob = require('glob');
+const pkg = require('../package.json');
 
 function createWorkers(count) {
   const workers = [];
@@ -30,7 +32,8 @@ function workerCount() {
  * Create a cache key from both the source, and the options used to minify the file.
  */
 function createCacheKey(source, options) {
-  return cache.createHashFromContent(source + JSON.stringify(options));
+  const content = `${source} ${JSON.stringify(options)} ${JSON.stringify(pkg)}`;
+  return cache.createHashFromContent(content);
 }
 
 /**
@@ -43,6 +46,25 @@ function retrieveFromCache(cacheKey, cacheDir) {
     } catch (e) { void(0); } // this just means it is uncached.
   }
   return null;
+}
+
+/**
+ * Remove unused files from the cache. This prevents the cache from growing indefinitely.
+ */
+function pruneCache(usedCacheKeys, allCacheKeys, cacheDir) {
+  if (cacheDir) {
+    const unusedKeys = allCacheKeys.filter(key => usedCacheKeys.indexOf(key) === -1);
+    unusedKeys.forEach(key => {
+      fs.unlinkSync(path.join(cacheDir, `${key}.js`));
+    });
+  }
+}
+
+function getCacheKeysFromDisk(cacheDir) {
+  if (cacheDir) {
+    return glob.sync(path.join(cacheDir, '*.js')).map(fileName => path.basename(fileName, '.js'));
+  }
+  return [];
 }
 
 /**
@@ -59,9 +81,12 @@ function saveToCache(cacheKey, minifiedCode, cacheDir) {
  * it sends a request to the worker to minify.  It may make more sense for the worker to handle
  * the cache, but sending the full source over ipc is expensive. Reading from disk is much faster.
  */
+const usedCacheKeys = [];
 function minify(assetName, asset, worker, options) {
   const assetContents = asset.source();
   const cacheKey = createCacheKey(assetContents, options);
+  usedCacheKeys.push(cacheKey);
+
   return new Promise((resolve, reject) => {
     const cachedContent = retrieveFromCache(cacheKey, options.cacheDir);
 
@@ -105,16 +130,20 @@ function processAssets(assetHash, options) {
   });
 
   return Promise.all(promises).then(() => {
+    // build is done, clean up the cache
+    pruneCache(usedCacheKeys, getCacheKeysFromDisk(options.cacheDir), options.cacheDir);
     workers.forEach(worker => worker.kill()); // workers are done, kill them.
   });
 }
 
 module.exports = {
-  processAssets,
-  workerCount,
-  createWorkers,
   createCacheKey,
+  createWorkers,
+  getCacheKeysFromDisk,
+  minify,
+  processAssets,
+  pruneCache,
   retrieveFromCache,
   saveToCache,
-  minify,
+  workerCount,
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
+    "glob": "^7.0.5",
     "mkdirp": "^0.5.1",
     "uglify-js": "^2.6.2",
     "webpack-sources": "^0.1.2"


### PR DESCRIPTION
Previous to this change, we weren't ever deleting files from the cache directory.  This could lead to unbounded growth if the cache isn't removed after many changes.