### PR TITLE
Switch to synchronous mkdirp.

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -119,7 +119,7 @@ function processAssets(compilation, options) {
   const assetHash = compilation.assets;
   const workers = createWorkers(workerCount());
   if (options.cacheDir) {
-    mkdirp(options.cacheDir);
+    mkdirp.sync(options.cacheDir);
   }
 
   const promises = Object.keys(assetHash).map((assetName, index) => {


### PR DESCRIPTION
Previously there was a bug for very small builds in that we could call mkdirp,
then minify a file and attempt to save it to cache before the directory was
created.  This switches to the synchronous version of mkdirp to prevent that.
This will negligibly impact performance as it is only called once per plugin,
and the call should only take milliseconds.