### PR TITLE
Limit memory usage

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,4 +1,8 @@
 const crypto = require('crypto');
+const fs = require('fs');
+const pkg = require('../package.json');
+const path = require('path');
+const glob = require('glob');
 
 // Small helper function to quickly create a hash from any given string.
 function createHashFromContent(content) {
@@ -7,6 +11,59 @@ function createHashFromContent(content) {
   return hash.digest('hex');
 }
 
+/**
+ * Create a cache key from both the source, and the options used to minify the file.
+ */
+function createCacheKey(source, options) {
+  const content = `${source} ${JSON.stringify(options)} ${JSON.stringify(pkg)}`;
+  return createHashFromContent(content);
+}
+
+/**
+ * Attempt to read from cache. If the read fails, or cacheDir isn't defined return null.
+ */
+function retrieveFromCache(cacheKey, cacheDir) {
+  if (cacheDir) {
+    try {
+      return fs.readFileSync(path.join(cacheDir, `${cacheKey}.js`), 'utf8');
+    } catch (e) { void(0); } // this just means it is uncached.
+  }
+  return null;
+}
+
+/**
+ * Remove unused files from the cache. This prevents the cache from growing indefinitely.
+ */
+function pruneCache(usedCacheKeys, allCacheKeys, cacheDir) {
+  if (cacheDir) {
+    const unusedKeys = allCacheKeys.filter(key => usedCacheKeys.indexOf(key) === -1);
+    unusedKeys.forEach(key => {
+      fs.unlinkSync(path.join(cacheDir, `${key}.js`));
+    });
+  }
+}
+
+function getCacheKeysFromDisk(cacheDir) {
+  if (cacheDir) {
+    return glob.sync(path.join(cacheDir, '*.js')).map(fileName => path.basename(fileName, '.js'));
+  }
+  return [];
+}
+
+/**
+ * Attempt to write the file to the cache.
+ */
+function saveToCache(cacheKey, minifiedCode, cacheDir) {
+  if (cacheDir) {
+    fs.writeFileSync(path.join(cacheDir, `${cacheKey}.js`), minifiedCode);
+  }
+}
+
 module.exports = {
   createHashFromContent,
+  createCacheKey,
+  retrieveFromCache,
+  pruneCache,
+  getCacheKeysFromDisk,
+  saveToCache,
 };

--- a/lib/tmp-file.js
+++ b/lib/tmp-file.js
@@ -1,0 +1,27 @@
+const tmp = require('tmp');
+const fs = require('fs');
+
+// make sure that we clean up the temp files even if the process exits unexpectedly
+tmp.setGracefulCleanup();
+
+function update(filename, newContent) {
+  fs.writeFileSync(filename, newContent, 'utf8');
+}
+
+module.exports = {
+  create(content) {
+    const filename = tmp.fileSync().name;
+    update(filename, content);
+    return filename;
+  },
+
+  remove(filename) {
+    fs.unlinkSync(filename);
+  },
+
+  update,
+
+  read(filename) {
+    return fs.readFileSync(filename, 'utf8');
+  },
+};

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -6,9 +6,7 @@ const mkdirp = require('mkdirp');
 const childProcess = require('child_process');
 const RawSource = require('webpack-sources').RawSource;
 const cache = require('./cache');
-const fs = require('fs');
-const glob = require('glob');
-const pkg = require('../package.json');
+const tmpFile = require('./tmp-file');
 
 function createWorkers(count) {
   const workers = [];
@@ -29,89 +27,33 @@ function workerCount() {
 }
 
 /**
- * Create a cache key from both the source, and the options used to minify the file.
- */
-function createCacheKey(source, options) {
-  const content = `${source} ${JSON.stringify(options)} ${JSON.stringify(pkg)}`;
-  return cache.createHashFromContent(content);
-}
-
-/**
- * Attempt to read from cache. If the read fails, or cacheDir isn't defined return null.
- */
-function retrieveFromCache(cacheKey, cacheDir) {
-  if (cacheDir) {
-    try {
-      return fs.readFileSync(path.join(cacheDir, `${cacheKey}.js`), 'utf8');
-    } catch (e) { void(0); } // this just means it is uncached.
-  }
-  return null;
-}
-
-/**
- * Remove unused files from the cache. This prevents the cache from growing indefinitely.
- */
-function pruneCache(usedCacheKeys, allCacheKeys, cacheDir) {
-  if (cacheDir) {
-    const unusedKeys = allCacheKeys.filter(key => usedCacheKeys.indexOf(key) === -1);
-    unusedKeys.forEach(key => {
-      fs.unlinkSync(path.join(cacheDir, `${key}.js`));
-    });
-  }
-}
-
-function getCacheKeysFromDisk(cacheDir) {
-  if (cacheDir) {
-    return glob.sync(path.join(cacheDir, '*.js')).map(fileName => path.basename(fileName, '.js'));
-  }
-  return [];
-}
-
-/**
- * Attempt to write the file to the cache.
- */
-function saveToCache(cacheKey, minifiedCode, cacheDir) {
-  if (cacheDir) {
-    fs.writeFileSync(path.join(cacheDir, `${cacheKey}.js`), minifiedCode);
-  }
-}
-
-/**
  * Minify an asset.  This attempts to read from the cache first, but if a cached version isn't found
  * it sends a request to the worker to minify.  It may make more sense for the worker to handle
  * the cache, but sending the full source over ipc is expensive. Reading from disk is much faster.
  */
 const usedCacheKeys = [];
 function minify(assetName, asset, worker, options) {
-  const assetContents = asset.source();
-  const cacheKey = createCacheKey(assetContents, options);
-  usedCacheKeys.push(cacheKey);
+  const tmpFileName = tmpFile.create(asset.source());
 
   return new Promise((resolve, reject) => {
-    const cachedContent = retrieveFromCache(cacheKey, options.cacheDir);
+    worker.send({
+      type: 'minify',
+      tmpFileName,
+      options,
+      assetName,
+    });
 
-    if (cachedContent) {
-      resolve(cachedContent);
-    } else {
-      worker.send({
-        type: 'minify',
-        options,
-        assetContents,
-        assetName,
-      });
-
-      worker.on('message', msg => {
-        if (msg.assetName === assetName) {
-          if (msg.type === 'success') {
-            const minifiedCode = msg.newContent;
-            saveToCache(cacheKey, minifiedCode, options.cacheDir);
-            resolve(minifiedCode);
-          } else {
-            reject(msg.errorMessage);
-          }
+    worker.on('message', msg => {
+      if (msg.assetName === assetName) {
+        if (msg.type === 'success') {
+          const minifiedCode = tmpFile.read(tmpFileName);
+          usedCacheKeys.push(msg.cacheKey);
+          resolve(minifiedCode);
+        } else {
+          reject(msg.errorMessage);
         }
-      });
-    }
+      }
+    });
   });
 }
 
@@ -134,19 +76,14 @@ function processAssets(compilation, options) {
 
   return Promise.all(promises).then(() => {
     // build is done, clean up the cache
-    pruneCache(usedCacheKeys, getCacheKeysFromDisk(options.cacheDir), options.cacheDir);
+    cache.pruneCache(usedCacheKeys, cache.getCacheKeysFromDisk(options.cacheDir), options.cacheDir);
     workers.forEach(worker => worker.kill()); // workers are done, kill them.
   });
 }
 
 module.exports = {
-  createCacheKey,
   createWorkers,
-  getCacheKeysFromDisk,
   minify,
   processAssets,
-  pruneCache,
-  retrieveFromCache,
-  saveToCache,
   workerCount,
 };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,4 +1,6 @@
 const uglify = require('uglify-js');
+const cache = require('./cache');
+const tmpFile = require('./tmp-file');
 
 function minify(source, uglifyOptions) {
   const opts = Object.assign({}, uglifyOptions, { fromString: true });
@@ -9,12 +11,19 @@ function messageHandler(msg) {
   if (msg.type === 'minify') {
     const assetName = msg.assetName;
     try {
-      const newContent = minify(msg.assetContents, msg.options.uglifyJS);
+      const assetContents = tmpFile.read(msg.tmpFileName);
+      const cacheKey = cache.createCacheKey(assetContents, msg.options);
+      const cachedContent = cache.retrieveFromCache(cacheKey, msg.options.cacheDir);
+      const newContent = cachedContent || minify(assetContents, msg.options.uglifyJS);
+      if (!cachedContent) {
+        cache.saveToCache(cacheKey, newContent, msg.options.cacheDir);
+      }
+      tmpFile.update(msg.tmpFileName, newContent);
 
       process.send({
         type: 'success',
-        newContent,
         assetName,
+        cacheKey,
       });
     } catch (e) {
       process.send({

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "glob": "^7.0.5",
     "mkdirp": "^0.5.1",
+    "tmp": "0.0.29",
     "uglify-js": "^2.6.2",
     "webpack-sources": "^0.1.2"
   }

--- a/test/lib/cache.js
+++ b/test/lib/cache.js
@@ -1,8 +1,98 @@
 import cache from '../../lib/cache';
 import test from 'ava';
+import path from 'path';
+import sinon from 'sinon';
+import fs from 'fs';
+import glob from 'glob';
+
+const testFiles = ['throw', 'test'];
+
+let stubbedRead;
+let stubbedWrite;
+let stubbedDelete;
+let stubbedGlob;
+test.beforeEach(() => {
+  const originalRead = fs.readFileSync;
+  stubbedRead = sinon.stub(fs, 'readFileSync', (filePath, encoding) => {
+    const fileName = path.basename(filePath, '.js');
+    if (testFiles.indexOf(fileName) === -1) {
+      return originalRead(filePath, encoding);
+    }
+    if (fileName === 'throw') throw new Error('error');
+    return 'filecontents';
+  });
+  stubbedDelete = sinon.stub(fs, 'unlinkSync');
+  stubbedWrite = sinon.stub(fs, 'writeFileSync');
+  stubbedGlob = sinon.stub(glob, 'sync', () => (
+    [
+      '/abs/file/path1.js',
+      '/abs/file/path2.js',
+    ]
+  ));
+});
+
+test.afterEach(() => {
+  stubbedRead.restore();
+  stubbedWrite.restore();
+  stubbedDelete.restore();
+  stubbedGlob.restore();
+});
 
 test('cacheKeyGenerator should return a sha256 hash for a given file name', t => {
   const result = cache.createHashFromContent('asdf');
   t.is(typeof result, 'string');
   t.is(result.length, 64);
+});
+
+test('retrieveFromCache should return cached content', t => {
+  const cacheDir = '/dev/null';
+  const cacheKey = 'test';
+  const result = cache.retrieveFromCache(cacheKey, cacheDir);
+  const cachedFile = path.join(cacheDir, `${cacheKey}.js`);
+  t.true(stubbedRead.calledWith(cachedFile));
+  t.is(result, 'filecontents');
+});
+
+test('retrieveFromCache should return a falsy value if the cache file does not exist', t => {
+  const cacheDir = '/dev/null';
+  const cacheKey = 'throw';
+  const result = cache.retrieveFromCache(cacheKey, cacheDir);
+  t.falsy(result);
+});
+
+test('saveToCache should write results to a cached file', t => {
+  const cacheDir = '/cacheDir';
+  const minifiedCode = 'minifiedCode;';
+  const cacheKey = 'mycachekey';
+  cache.saveToCache(cacheKey, minifiedCode, cacheDir);
+  t.true(stubbedWrite.calledWith(path.join(cacheDir, `${cacheKey}.js`), minifiedCode));
+});
+
+test('saveToCache should not write anything if no cacheDir is defined', t => {
+  const minifiedCode = 'minifiedCode;';
+  const cacheKey = 'mycachekey';
+  cache.saveToCache(cacheKey, minifiedCode, undefined);
+  t.false(stubbedWrite.called);
+});
+
+test('pruneCache is a noop if cacheDir is not provided', () => {
+  cache.pruneCache('invalidbutunused', 'alsoinvalidbutunused', undefined);
+});
+
+test('pruneCache removes cache files that are unused', t => {
+  cache.pruneCache(['usedKey'], ['usedKey', 'unusedKey1', 'unusedKey2'], 'cacheDir');
+  t.true(stubbedDelete.calledWith(path.join('cacheDir', 'unusedKey1.js')));
+  t.true(stubbedDelete.calledWith(path.join('cacheDir', 'unusedKey2.js')));
+  t.false(stubbedDelete.calledWith(path.join('cacheDir', 'usedKey.js')));
+});
+
+test('getCacheKeysFromDisk returns the filename of js files in the cacheDir', t => {
+  const result = cache.getCacheKeysFromDisk('doesnotmatter');
+  t.is(result[0], 'path1');
+  t.is(result[1], 'path2');
+});
+
+test('getCacheKeysFromDisk returns an emtpy array if a cacheDir is not provided', t => {
+  const result = cache.getCacheKeysFromDisk(undefined);
+  t.deepEqual(result, []);
 });

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -4,16 +4,11 @@ import fs from 'fs';
 import os from 'os';
 import childProcess from 'child_process';
 import path from 'path';
-import glob from 'glob';
 
 const stubbedOn = sinon.stub(process, 'on');
 const {
   createWorkers,
-  getCacheKeysFromDisk,
   minify,
-  pruneCache,
-  retrieveFromCache,
-  saveToCache,
   workerCount,
 } = require('../../lib/uglifier');
 
@@ -22,7 +17,6 @@ stubbedOn.restore();
 let stubbedRead;
 let stubbedWrite;
 let stubbedDelete;
-let stubbedGlob;
 test.beforeEach(() => {
   stubbedRead = sinon.stub(fs, 'readFileSync', (filePath) => {
     const fileName = path.basename(filePath, '.js');
@@ -31,12 +25,6 @@ test.beforeEach(() => {
   });
   stubbedDelete = sinon.stub(fs, 'unlinkSync');
   stubbedWrite = sinon.stub(fs, 'writeFileSync');
-  stubbedGlob = sinon.stub(glob, 'sync', () => (
-    [
-      '/abs/file/path1.js',
-      '/abs/file/path2.js',
-    ]
-  ));
 });
 
 const fakeWorker = {
@@ -49,7 +37,6 @@ test.afterEach(() => {
   stubbedRead.restore();
   stubbedWrite.restore();
   stubbedDelete.restore();
-  stubbedGlob.restore();
 });
 
 test('workerCount should be cpus - 1', t => {
@@ -69,57 +56,4 @@ test('minify should return a Promise', t => {
   const promise = minify('uglifier.js', { source: () => 'asdf;' }, fakeWorker, {});
   // ava uses babel for tests so Promise probably isn't node Promise.
   t.is(typeof promise.then, 'function');
-});
-
-test('retrieveFromCache should return cached content', t => {
-  const cacheDir = '/dev/null';
-  const cacheKey = 'test';
-  const result = retrieveFromCache(cacheKey, cacheDir);
-  const cachedFile = path.join(cacheDir, `${cacheKey}.js`);
-  t.true(stubbedRead.calledWith(cachedFile));
-  t.is(result, 'filecontents');
-});
-
-test('retrieveFromCache should return a falsy value if the cache file does not exist', t => {
-  const cacheDir = '/dev/null';
-  const cacheKey = 'throw';
-  const result = retrieveFromCache(cacheKey, cacheDir);
-  t.falsy(result);
-});
-
-test('saveToCache should write results to a cached file', t => {
-  const cacheDir = '/cacheDir';
-  const minifiedCode = 'minifiedCode;';
-  const cacheKey = 'mycachekey';
-  saveToCache(cacheKey, minifiedCode, cacheDir);
-  t.true(stubbedWrite.calledWith(path.join(cacheDir, `${cacheKey}.js`), minifiedCode));
-});
-
-test('saveToCache should not write anything if no cacheDir is defined', t => {
-  const minifiedCode = 'minifiedCode;';
-  const cacheKey = 'mycachekey';
-  saveToCache(cacheKey, minifiedCode, undefined);
-  t.false(stubbedWrite.called);
-});
-
-test('getCacheKeysFromDisk returns the filename of js files in the cacheDir', t => {
-  const result = getCacheKeysFromDisk('doesnotmatter');
-  t.is(result[0], 'path1');
-  t.is(result[1], 'path2');
-});
-
-test('getCacheKeysFromDisk returns an emtpy array if a cacheDir is not provided', t => {
-  const result = getCacheKeysFromDisk(undefined);
-  t.deepEqual(result, []);
-});
-
-test('pruneCache is a noop if cacheDir is not provided', () => {
-  pruneCache('invalidbutunused', 'alsoinvalidbutunused', undefined);
-});
-
-test('pruneCache removes cache files that are unused', t => {
-  pruneCache(['usedKey'], ['usedKey', 'unusedKey1', 'unusedKey2'], 'cacheDir');
-  t.true(stubbedDelete.calledWith(path.join('cacheDir', 'unusedKey1.js')));
-  t.true(stubbedDelete.calledWith(path.join('cacheDir', 'unusedKey2.js')));
-  t.false(stubbedDelete.calledWith(path.join('cacheDir', 'usedKey.js')));
 });

--- a/test/lib/worker.js
+++ b/test/lib/worker.js
@@ -1,6 +1,11 @@
 import test from 'ava';
 import uglify from 'uglify-js';
 import sinon from 'sinon';
+import tmpFile from '../../lib/tmp-file';
+import cache from '../../lib/cache';
+
+const originalContent = 'function  test   ()    {   void(0); }';
+const minifiedContent = uglify.minify(originalContent, { fromString: true }).code;
 
 // ava is multi process and uses process.on,
 // so we stub it to be sure it doesn't get in the way.
@@ -8,25 +13,42 @@ const stubbedOn = sinon.stub(process, 'on');
 const messageHandler = require('../../lib/worker');
 stubbedOn.restore();
 
+let stubbedRead;
+let stubbedUpdate;
+test.beforeEach(() => {
+  stubbedRead = sinon.stub(tmpFile, 'read', () => originalContent);
+  stubbedUpdate = sinon.stub(tmpFile, 'update');
+});
+
+test.afterEach(() => {
+  stubbedRead.restore();
+  stubbedUpdate.restore();
+});
+
 test('messageHandler should handle minify messages, minifying the provided file.', t => {
   const stubbedSend = sinon.stub(process, 'send');
+  const stubbedRetrieve = sinon.stub(cache, 'retrieveFromCache', () => undefined);
   const assetName = 'abc';
-  const originalContent = 'function  test   ()    {   void(0); }';
+  const tmpFileName = 'asdf';
+  const options = {
+    uglifyJS: {
+      bunk: true,
+    },
+  };
+
   messageHandler({
     type: 'minify',
     assetName,
-    assetContents: originalContent,
-    options: {
-      uglifyJS: {
-        bunk: true,
-      },
-    },
+    tmpFileName,
+    options,
   });
 
+  t.true(stubbedUpdate.calledWith(tmpFileName, minifiedContent));
   t.true(stubbedSend.calledWith({
-    type: 'success',
     assetName,
-    newContent: uglify.minify(originalContent, { fromString: true }).code,
+    type: 'success',
+    cacheKey: cache.createCacheKey(originalContent, options),
   }));
   stubbedSend.restore();
+  stubbedRetrieve.restore();
 });


### PR DESCRIPTION
This helps us to avoid loading all of the content of assets files in
memory at the same time, which was leading to out of memory
errors on large builds.