### PR TITLE
Limit minification to js files.

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -64,7 +64,9 @@ function processAssets(compilation, options) {
     mkdirp.sync(options.cacheDir);
   }
 
-  const promises = Object.keys(assetHash).map((assetName, index) => {
+  const assets = Object.keys(assetHash).filter(assetName => /\.js$/.test(assetName));
+
+  const promises = assets.map((assetName, index) => {
     const asset = assetHash[assetName];
     const worker = workers[index % workers.length];
     return minify(assetName, asset, worker, options).then(msgContent => {


### PR DESCRIPTION
Previously the plugin was attempting to minify all build output using uglify.
This created issues for users using file-loader to build image/css files.

Fixes - https://github.com/gdborton/webpack-parallel-uglify-plugin/issues/3