### PR TITLE
Add note about not supporting source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This plugin serves to help projects with many entry points speed up their builds.  The UglifyJS plugin provided with webpack runs sequentially on each of the output files.  This plugin runs uglify in parallel with one thread for each of your available cpus.  This can lead to significantly reduced build times as minification is very CPU intensive.
 
+#### Important note: at the moment, this plugin does not support source maps.
+
 ## Config
 
 Configuring is straightforward.


### PR DESCRIPTION
Related to https://github.com/gdborton/webpack-parallel-uglify-plugin/issues/7
I spent a couple of hours troubleshooting till I discovered the plugin doesn't support source maps, and would like to save that from others!