### PR TITLE
Separate cacheDir from other options passed to worker

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -32,7 +32,7 @@ function workerCount(assetCount) {
  * the cache, but sending the full source over ipc is expensive. Reading from disk is much faster.
  */
 const usedCacheKeys = [];
-function minify(assetName, asset, worker, options) {
+function minify(assetName, asset, worker, cacheDir, options) {
   const tmpFileName = tmpFile.create(asset.source());
 
   return new Promise((resolve, reject) => {
@@ -41,6 +41,7 @@ function minify(assetName, asset, worker, options) {
       tmpFileName,
       options,
       assetName,
+      cacheDir,
     });
 
     worker.on('message', msg => {
@@ -62,6 +63,12 @@ function processAssets(compilation, options) {
   if (options.cacheDir) {
     mkdirp.sync(options.cacheDir);
   }
+
+  // Create a copy of the options object that omits the cacheDir field. This is necessary because
+  // we include the options object when creating cache keys, and some cache directory paths may not
+  // be stable across multiple runs.
+  const optionsWithoutCacheDir = Object.assign({}, options);
+  optionsWithoutCacheDir.cacheDir = undefined;
 
   const assets = Object.keys(assetHash).filter(assetName => /\.js$/.test(assetName));
 
@@ -89,11 +96,12 @@ function processAssets(compilation, options) {
   const promises = uncachedAssets.map((assetName, index) => {
     const asset = assetHash[assetName];
     const worker = workers[index % workers.length];
-    return minify(assetName, asset, worker, options).then(msgContent => {
-      assetHash[assetName] = new RawSource(msgContent); // eslint-disable-line no-param-reassign
-    }).catch((e) => {
-      compilation.errors.push(new Error(`minifying ${assetName}\n${e}`));
-    });
+    return minify(assetName, asset, worker, options.cacheDir, optionsWithoutCacheDir)
+      .then(msgContent => {
+        assetHash[assetName] = new RawSource(msgContent); // eslint-disable-line no-param-reassign
+      }).catch((e) => {
+        compilation.errors.push(new Error(`minifying ${assetName}\n${e}`));
+      });
   });
 
   return Promise.all(promises).then(() => {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -16,7 +16,7 @@ function messageHandler(msg) {
       // We do not check the cache here because we already determined that this asset yields a cache
       // miss in the parent process.
       const minifiedContent = minify(assetContents, msg.options.uglifyJS);
-      cache.saveToCache(cacheKey, minifiedContent, msg.options.cacheDir);
+      cache.saveToCache(cacheKey, minifiedContent, msg.cacheDir);
       tmpFile.update(msg.tmpFileName, minifiedContent);
 
       process.send({


### PR DESCRIPTION
This makes it so we pass a copy of the options object without the
`cacheDir` field to the worker. This way the worker only uses this
modified options object when creating cache keys for files. The
`cacheDir` value should generally not be factored into the cache key
derivation, and this specifically helps if the `cacheDir` value is not
consistent across runs.