### PR TITLE
Perform cache reading in parent process to create fewer processes

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -20,10 +20,10 @@ function createWorkers(count) {
 
 /**
  * Determines how many workers to create.
- * Should be available cpus minus 1.
+ * Should be available cpus minus 1 or the number of assets to minify, whichever is smaller.
  */
-function workerCount() {
-  return Math.max(1, os.cpus().length - 1);
+function workerCount(assetCount) {
+  return Math.min(assetCount, Math.max(1, os.cpus().length - 1));
 }
 
 /**
@@ -59,14 +59,34 @@ function minify(assetName, asset, worker, options) {
 
 function processAssets(compilation, options) {
   const assetHash = compilation.assets;
-  const workers = createWorkers(workerCount());
   if (options.cacheDir) {
     mkdirp.sync(options.cacheDir);
   }
 
   const assets = Object.keys(assetHash).filter(assetName => /\.js$/.test(assetName));
 
-  const promises = assets.map((assetName, index) => {
+  // For assets that are cached, we read from the cache here rather than doing so in the worker.
+  // This is a relatively fast operation, so this lets us avoid creating several workers in cases
+  // when we have a near 100% cache hit rate.
+  const cacheKeysOnDisk = new Set(cache.getCacheKeysFromDisk(options.cacheDir));
+  const uncachedAssets = [];
+  for (let i = 0; i < assets.length; i++) {
+    const name = assets[i];
+    const cacheKey = cache.createCacheKey(assetHash[name].source(), options);
+    if (cacheKeysOnDisk.has(cacheKey)) {
+      // Cache hit, so let's read from the disk and mark this cache key as used.
+      const content = cache.retrieveFromCache(cacheKey, options.cacheDir);
+      assetHash[name] = new RawSource(content);
+      usedCacheKeys.push(cacheKey);
+    } else {
+      // Cache miss, so we'll need to minify this in a worker.
+      uncachedAssets.push(name);
+    }
+  }
+
+  const workers = createWorkers(workerCount(uncachedAssets.length));
+
+  const promises = uncachedAssets.map((assetName, index) => {
     const asset = assetHash[assetName];
     const worker = workers[index % workers.length];
     return minify(assetName, asset, worker, options).then(msgContent => {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -13,12 +13,11 @@ function messageHandler(msg) {
     try {
       const assetContents = tmpFile.read(msg.tmpFileName);
       const cacheKey = cache.createCacheKey(assetContents, msg.options);
-      const cachedContent = cache.retrieveFromCache(cacheKey, msg.options.cacheDir);
-      const newContent = cachedContent || minify(assetContents, msg.options.uglifyJS);
-      if (!cachedContent) {
-        cache.saveToCache(cacheKey, newContent, msg.options.cacheDir);
-      }
-      tmpFile.update(msg.tmpFileName, newContent);
+      // We do not check the cache here because we already determined that this asset yields a cache
+      // miss in the parent process.
+      const minifiedContent = minify(assetContents, msg.options.uglifyJS);
+      cache.saveToCache(cacheKey, minifiedContent, msg.options.cacheDir);
+      tmpFile.update(msg.tmpFileName, minifiedContent);
 
       process.send({
         type: 'success',

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -39,9 +39,17 @@ test.afterEach(() => {
   stubbedDelete.restore();
 });
 
-test('workerCount should be cpus - 1', t => {
+test('workerCount should be cpus - 1 if assetCount is >= cpus', t => {
   const cpuStub = sinon.stub(os, 'cpus', () => ({ length: 8 }));
-  t.is(workerCount(), 7);
+  const assetCount = 10;
+  t.is(workerCount(assetCount), 7);
+  cpuStub.restore();
+});
+
+test('workerCount should be assetCount if assetCount is < cpus', t => {
+  const cpuStub = sinon.stub(os, 'cpus', () => ({ length: 8 }));
+  const assetCount = 5;
+  t.is(workerCount(assetCount), 5);
   cpuStub.restore();
 });
 


### PR DESCRIPTION
This moves the cache reading logic into the parent process in an effort to fork fewer child processes when the cache hit rate is very high. Forking several dozen processes appears to have a noticeable overhead, so only forking processes when necessary can help to alleviate this. We do this by copying cached data into the compilation output in the parent process, and then only sending files to worker processes if the files do not already appear in the cache. Doing this work in the parent process appears to take a relatively insignificant amount of time.