### PR TITLE
Fix bug where cache keys were generated incorrectly

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -79,7 +79,7 @@ function processAssets(compilation, options) {
   const uncachedAssets = [];
   for (let i = 0; i < assets.length; i++) {
     const name = assets[i];
-    const cacheKey = cache.createCacheKey(assetHash[name].source(), options);
+    const cacheKey = cache.createCacheKey(assetHash[name].source(), optionsWithoutCacheDir);
     if (cacheKeysOnDisk.has(cacheKey)) {
       // Cache hit, so let's read from the disk and mark this cache key as used.
       const content = cache.retrieveFromCache(cacheKey, options.cacheDir);


### PR DESCRIPTION
My previous two PRs had a logic conflict that was causing us to not read
from the cache correctly.