### PR TITLE
Change cacheKey generation from JSON.stringify to a regular string.

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -91,11 +91,8 @@ function processAssets(compilation, options) {
   assets.forEach((name) => {
     // sourceAndMap() is an expensive function, so we'll create the cache key from just source(),
     // and whether or not we should be using source maps.
-    const cacheKey = cache.createCacheKey(JSON.stringify({
-      source: assetHash[name].source(),
-      useSourceMaps,
-    }), optionsWithoutCacheDir);
-
+    const source = assetHash[name].source();
+    const cacheKey = cache.createCacheKey(source + useSourceMaps, optionsWithoutCacheDir);
     if (cacheKeysOnDisk.has(cacheKey)) {
       // Cache hit, so let's read from the disk and mark this cache key as used.
       const content = JSON.parse(cache.retrieveFromCache(cacheKey, options.cacheDir));

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -30,10 +30,8 @@ function messageHandler(msg) {
       const sourceAndMap = JSON.parse(messageContents);
       const source = sourceAndMap.source;
       const map = sourceAndMap.map;
-      const cacheKey = cache.createCacheKey(JSON.stringify({
-        source,
-        useSourceMaps: !!map,
-      }), msg.options);
+
+      const cacheKey = cache.createCacheKey(source + !!map, msg.options);
       // We do not check the cache here because we already determined that this asset yields a cache
       // miss in the parent process.
       const minifiedContent = minify(source, map, msg.options.uglifyJS);

--- a/test/lib/worker.js
+++ b/test/lib/worker.js
@@ -65,7 +65,7 @@ test('messageHandler should handle minify messages, minifying the provided file.
 
   t.true(stubbedUpdate.calledWith(tmpFileName, JSON.stringify(minifiedContent)));
   const cacheKey = cache.createCacheKey(
-    JSON.stringify({ source: codeSource, useSourceMaps: false }),
+    codeSource + false,
     options
   );
   t.true(stubbedSend.calledWith({


### PR DESCRIPTION
Using JSON.stringify on an object containing an asset's source was pretty slow.
Concatenating the source with the useSourceMaps variable still produces a
unique string, and is many times faster.