### PR TITLE
Check for source map plugins if devtool is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ module.exports = {
       exclude, // Optional regex, or array of regex to exclude from minification. Matching files are not minified.
       cacheDir, // Optional absolute path to use as a cache. If not provided, caching will not be used.
       workerCount, // Optional int. Number of workers to run uglify. Defaults to num of cpus - 1 or asset count (whichever is smaller)
+      sourceMap, // Optional Boolean. This slows down the compilation. Defaults to false.
       uglifyJS: {
         // These pass straight through to uglify.
       },

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -23,7 +23,7 @@ const usedCacheKeys = [];
 
 function processAssets(compilation, options) {
   const assetHash = compilation.assets;
-  const useSourceMaps = !!compilation.options.devtool;
+  const useSourceMaps = options.sourceMap || false;
   if (options.cacheDir) {
     mkdirp.sync(options.cacheDir);
   }

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -13,6 +13,15 @@ const testedFilename = 'testedFilename.js';
 const unminifedSource = 'function    name()   {   }';
 const minifiedSource = 'function name(){}';
 
+const sourceMap = JSON.stringify({
+  version: 3,
+  file: 'somefile.js.map',
+  sources: [],
+  sourceRoot: '/',
+  names: ['name'],
+  mappings: '',
+});
+
 function createFakeCompilationObject() {
   return {
     assets: {
@@ -20,10 +29,16 @@ function createFakeCompilationObject() {
         source() {
           return unminifedSource;
         },
+        map() {
+          return sourceMap;
+        },
       },
       [testedFilename]: {
         source() {
           return unminifedSource;
+        },
+        map() {
+          return sourceMap;
         },
       },
     },
@@ -89,6 +104,27 @@ test.cb('processAssets respects exclude option', (t) => {
     const matchedResult = fakeCompilationObject.assets[testedFilename].source();
     t.is(unmatchedResult, minifiedSource);
     t.is(matchedResult, unminifedSource);
+    t.end();
+  });
+});
+
+test.cb('processAssets respects uglifyJS.sourceMap option', (t) => {
+  const fakeCompilationObject = createFakeCompilationObject();
+  processAssets(fakeCompilationObject, {
+    sourceMap: true,
+    uglifyJS: { },
+  }).then(() => {
+    const assetSourceMap = fakeCompilationObject.assets[filename];
+    t.is(assetSourceMap.map(), sourceMap);
+    t.end();
+  });
+
+  processAssets(fakeCompilationObject, {
+    sourceMap: false,
+    uglifyJS: { },
+  }).then(() => {
+    const assetSourceMap = fakeCompilationObject.assets[filename];
+    t.is(assetSourceMap.map(), null);
     t.end();
   });
 });


### PR DESCRIPTION
devtools doesn't allow setting some options that the plugins provide. This checks for the currently available source map plugins in the configured plugins to ensure we use the SourceMapSource instead
