### PR TITLE
Major refactor away from child_process and to worker-farm.

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -1,25 +1,15 @@
 'use strict'; // eslint-disable-line strict
 
 const os = require('os');
-const path = require('path');
 const mkdirp = require('mkdirp');
-const childProcess = require('child_process');
 const webpackSources = require('webpack-sources');
+const workerFarm = require('worker-farm');
+const pify = require('pify');
+
 const SourceMapSource = webpackSources.SourceMapSource;
 const RawSource = webpackSources.RawSource;
 const cache = require('./cache');
 const tmpFile = require('./tmp-file');
-
-function createWorkers(count) {
-  const workers = [];
-  while (workers.length < count) {
-    const worker = childProcess.fork(path.join(__dirname, './worker.js'));
-    worker.setMaxListeners(100);
-    workers.push(worker);
-  }
-  return workers;
-}
-
 /**
  * Determines how many workers to create.
  * Should be available cpus minus 1 or the number of assets to minify, whichever is smaller.
@@ -28,44 +18,7 @@ function workerCount(assetCount) {
   return Math.min(assetCount, Math.max(1, os.cpus().length - 1));
 }
 
-/**
- * Minify an asset.  This attempts to read from the cache first, but if a cached version isn't found
- * it sends a request to the worker to minify.  It may make more sense for the worker to handle
- * the cache, but sending the full source over ipc is expensive. Reading from disk is much faster.
- */
 const usedCacheKeys = [];
-function minify(assetName, asset, useSourceMaps, worker, cacheDir, options) {
-  const tmpFileName = tmpFile.create(JSON.stringify({
-    source: asset.source(),
-    map: useSourceMaps ? asset.map() : null,
-  }));
-
-  return new Promise((resolve, reject) => {
-    worker.send({
-      type: 'minify',
-      tmpFileName,
-      options,
-      assetName,
-      cacheDir,
-    });
-
-    worker.on('message', msg => {
-      if (msg.assetName === assetName) {
-        if (msg.type === 'success') {
-          const result = JSON.parse(tmpFile.read(tmpFileName));
-          usedCacheKeys.push(msg.cacheKey);
-          resolve({
-            source: result.code,
-            map: result.map,
-            name: assetName,
-          });
-        } else {
-          reject(msg.errorMessage);
-        }
-      }
-    });
-  });
-}
 
 function processAssets(compilation, options) {
   const assetHash = compilation.assets;
@@ -88,54 +41,74 @@ function processAssets(compilation, options) {
   const cacheKeysOnDisk = new Set(cache.getCacheKeysFromDisk(options.cacheDir));
   const uncachedAssets = [];
 
-  assets.forEach((name) => {
+  assets.forEach((assetName) => {
     // sourceAndMap() is an expensive function, so we'll create the cache key from just source(),
     // and whether or not we should be using source maps.
-    const source = assetHash[name].source();
+    const source = assetHash[assetName].source();
     const cacheKey = cache.createCacheKey(source + useSourceMaps, optionsWithoutCacheDir);
+    usedCacheKeys.push(cacheKey);
     if (cacheKeysOnDisk.has(cacheKey)) {
       // Cache hit, so let's read from the disk and mark this cache key as used.
       const content = JSON.parse(cache.retrieveFromCache(cacheKey, options.cacheDir));
       if (content.map) {
-        assetHash[name] = new SourceMapSource(content.source, name, content.map);
+        assetHash[assetName] = new SourceMapSource(content.source, assetName, content.map);
       } else {
-        assetHash[name] = new RawSource(content.source);
+        assetHash[assetName] = new RawSource(content.source);
       }
-      usedCacheKeys.push(cacheKey);
     } else {
       // Cache miss, so we'll need to minify this in a worker.
-      uncachedAssets.push(name);
+      uncachedAssets.push(assetName);
     }
   });
 
-  const numWorkers = options.workerCount || workerCount(uncachedAssets.length);
-  const workers = createWorkers(numWorkers);
+  const farm = workerFarm({
+    autoStart: true,
+    maxConcurrentCallsPerWorker: 1,
+    maxConcurrentWorkers: workerCount(uncachedAssets.length),
+    maxRetries: 2, // Allow for a couple of transient errors.
+  },
+   require.resolve('./worker'),
+   ['processMessage']
+  );
 
-  const promises = uncachedAssets.map((assetName, index) => {
+  const minify = pify(farm.processMessage);
+
+  const minificationPromises = uncachedAssets.map((assetName) => {
     const asset = assetHash[assetName];
-    const worker = workers[index % workers.length];
-    return minify(assetName, asset, useSourceMaps, worker, options.cacheDir, optionsWithoutCacheDir)
-      .then(msgContent => {
-        if (msgContent.map) {
-          assetHash[assetName] = new SourceMapSource(msgContent.source, msgContent.name, msgContent.map); // eslint-disable-line no-param-reassign, max-len
+    const tmpFileName = tmpFile.create(JSON.stringify({
+      assetName,
+      options: optionsWithoutCacheDir,
+      source: asset.source(),
+      map: useSourceMaps ? asset.map() : null,
+      cacheDir: options.cacheDir,
+    }));
+
+    return minify(tmpFileName)
+      .then(() => {
+        const content = tmpFile.read(tmpFileName);
+        const msg = JSON.parse(content);
+        if (msg.map) {
+          assetHash[assetName] = new SourceMapSource(msg.source, assetName, msg.map); // eslint-disable-line no-param-reassign, max-len
         } else {
-          assetHash[assetName] = new RawSource(msgContent.source); // eslint-disable-line no-param-reassign, max-len
+          assetHash[assetName] = new RawSource(msg.source); // eslint-disable-line no-param-reassign, max-len
         }
-      }).catch((e) => {
+      })
+      .catch((e) => {
         compilation.errors.push(new Error(`minifying ${assetName}\n${e}`));
       });
   });
 
-  return Promise.all(promises).then(() => {
-    // build is done, clean up the cache
+  function performCleanUp() {
     cache.pruneCache(usedCacheKeys, cache.getCacheKeysFromDisk(options.cacheDir), options.cacheDir);
-    workers.forEach(worker => worker.kill()); // workers are done, kill them.
-  });
+    workerFarm.end(farm); // at this point we're done w/ the farm, it can be killed
+  }
+
+  return Promise.all(minificationPromises)
+    .then(performCleanUp)
+    .catch(performCleanUp);
 }
 
 module.exports = {
-  createWorkers,
-  minify,
   processAssets,
   workerCount,
 };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,7 +2,7 @@ const uglify = require('uglify-js');
 const cache = require('./cache');
 const tmpFile = require('./tmp-file');
 const BOGUS_SOURCEMAP_STRING = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
- // This has to be broken apart or ava/nyc will try to use it when creating coverage reports.
+// This has to be broken apart or ava/nyc will try to use it when creating coverage reports.
 const URL_PREFIX = '//# sourceMappingURL=';
 const BOGUS_SOURCEMAP_URL = `\n${URL_PREFIX}${BOGUS_SOURCEMAP_STRING}`;
 
@@ -22,44 +22,51 @@ function minify(source, map, uglifyOptions) {
   return result;
 }
 
-function messageHandler(msg) {
-  if (msg.type === 'minify') {
-    const assetName = msg.assetName;
-    try {
-      const messageContents = tmpFile.read(msg.tmpFileName);
-      const sourceAndMap = JSON.parse(messageContents);
-      const source = sourceAndMap.source;
-      const map = sourceAndMap.map;
+/**
+ * Note: We're passing messages via tmpFiles as this is faster than passing through ipc.
+ * In this function msgLocation is the tmp file's name, so that we know where to look
+ * for our message.
+ *
+ * We expect the messages to have the following format:
+ * {
+ *   assetName: 'someFileName.js',
+ *   source: 'function() {}',
+ *   map: 'a source map string if enabled',
+ *   cacheDir: 'location to cache results',
+ *   options: {
+ *     pluginOptions,
+ *   },
+ * }
+ */
 
-      const cacheKey = cache.createCacheKey(source + !!map, msg.options);
-      // We do not check the cache here because we already determined that this asset yields a cache
-      // miss in the parent process.
-      const minifiedContent = minify(source, map, msg.options.uglifyJS);
-      cache.saveToCache(cacheKey, JSON.stringify({
-        source: minifiedContent.code,
-        map: minifiedContent.map,
-      }), msg.cacheDir);
+function processMessage(msgLocation, callback) {
+  try {
+    const messageContents = tmpFile.read(msgLocation);
+    const message = JSON.parse(messageContents);
+    const source = message.source;
+    const map = message.map;
 
-      tmpFile.update(msg.tmpFileName, JSON.stringify(minifiedContent));
+    const cacheKey = cache.createCacheKey(source + !!map, message.options);
+    // We do not check the cache here because we already determined that this asset yields a cache
+    // miss in the parent process.
+    const minifiedContent = minify(source, map, message.options.uglifyJS);
+    cache.saveToCache(cacheKey, JSON.stringify({
+      source: minifiedContent.code,
+      map: minifiedContent.map,
+    }), message.cacheDir);
 
-      process.send({
-        type: 'success',
-        assetName,
-        cacheKey,
-      });
-    } catch (e) {
-      process.send({
-        type: 'error',
-        errorMessage: e.message,
-        assetName,
-      });
-    }
+    tmpFile.update(msgLocation, JSON.stringify({
+      source: minifiedContent.code,
+      map: minifiedContent.map,
+      cacheKey,
+    }));
+    callback(null, msgLocation);
+  } catch (e) {
+    callback(e.message, msgLocation);
   }
 }
 
-process.on('message', messageHandler);
-
 module.exports = {
-  messageHandler,
   minify,
+  processMessage,
 };

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
   "dependencies": {
     "glob": "^7.0.5",
     "mkdirp": "^0.5.1",
+    "pify": "^3.0.0",
     "tmp": "0.0.29",
     "uglify-js": "^2.6.2",
-    "webpack-sources": "^0.1.2"
+    "webpack-sources": "^0.1.2",
+    "worker-farm": "^1.3.1"
   }
 }

--- a/test/lib/tmp-file.js
+++ b/test/lib/tmp-file.js
@@ -1,0 +1,32 @@
+import test from 'ava';
+import fs from 'fs';
+import tmpFile from '../../lib/tmp-file';
+
+const myContent = 'somecontent';
+
+test('tmpFile.create creates a real file and retuns its filename', (t) => {
+  const fileName = tmpFile.create(myContent);
+  t.truthy(fs.existsSync(fileName));
+  t.is(fs.readFileSync(fileName, 'utf8'), myContent);
+  fs.unlinkSync(fileName);
+});
+
+test('tmpFile.update updates the tmpFile\'s content synchronously', (t) => {
+  const tmpFileName = tmpFile.create('randoContent');
+  tmpFile.update(tmpFileName, myContent);
+  t.is(fs.readFileSync(tmpFileName, 'utf8'), myContent);
+  fs.unlinkSync(tmpFileName);
+});
+
+test('tmpFile.remove deletes the file from disk', (t) => {
+  const tmpFileName = tmpFile.create(myContent);
+  t.truthy(fs.existsSync(tmpFileName));
+  tmpFile.remove(tmpFileName);
+  t.falsy(fs.existsSync(tmpFileName));
+});
+
+test('tmpFile.read functions reads tmpFile contents synchronously', (t) => {
+  const tmpFileName = tmpFile.create(myContent);
+  t.is(tmpFile.read(tmpFileName), fs.readFileSync(tmpFileName, 'utf8'));
+  fs.unlinkSync(tmpFileName);
+});

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -2,13 +2,10 @@ import test from 'ava';
 import sinon from 'sinon';
 import fs from 'fs';
 import os from 'os';
-import childProcess from 'child_process';
 import path from 'path';
 
 const stubbedOn = sinon.stub(process, 'on');
 const {
-  createWorkers,
-  minify,
   workerCount,
 } = require('../../lib/uglifier');
 
@@ -26,12 +23,6 @@ test.beforeEach(() => {
   stubbedDelete = sinon.stub(fs, 'unlinkSync');
   stubbedWrite = sinon.stub(fs, 'writeFileSync');
 });
-
-const fakeWorker = {
-  on: () => {},
-  send: () => {},
-  setMaxListeners: () => {},
-};
 
 test.afterEach(() => {
   stubbedRead.restore();
@@ -51,23 +42,4 @@ test('workerCount should be assetCount if assetCount is < cpus', t => {
   const assetCount = 5;
   t.is(workerCount(assetCount), 5);
   cpuStub.restore();
-});
-
-test('createWorkers should fork x times', t => {
-  const stubbedFork = sinon.stub(childProcess, 'fork', () => fakeWorker);
-  createWorkers(12);
-  t.is(stubbedFork.callCount, 12);
-  stubbedFork.restore();
-});
-
-test('minify should return a Promise', t => {
-  const promise = minify(
-    'uglifier.js', // assetName
-    { source: () => 'asdf;' }, // asset
-    false, // useSourceMaps
-    fakeWorker, // worker
-    {}
-  );
-  // ava uses babel for tests so Promise probably isn't node Promise.
-  t.is(typeof promise.then, 'function');
 });

--- a/test/lib/worker.js
+++ b/test/lib/worker.js
@@ -2,7 +2,6 @@ import test from 'ava';
 import uglify from 'uglify-js';
 import sinon from 'sinon';
 import tmpFile from '../../lib/tmp-file';
-import cache from '../../lib/cache';
 import { RawSource, OriginalSource } from 'webpack-sources';
 
 const codeSource = 'function  test   ()    {   void(0); }';
@@ -15,7 +14,6 @@ const minifiedContent = uglify.minify(codeSource, { fromString: true });
 // so we stub it to be sure it doesn't get in the way.
 const stubbedOn = sinon.stub(process, 'on');
 const worker = require('../../lib/worker');
-const messageHandler = worker.messageHandler;
 const minify = worker.minify;
 
 stubbedOn.restore();
@@ -44,34 +42,4 @@ test('minify should return a valid source map if called with an OriginalSource o
   const result = minify(codeSource, map);
   t.truthy(result.map);
   t.is(result.code, minifiedContent.code); // should produce the same minified content.
-});
-
-test('messageHandler should handle minify messages, minifying the provided file.', t => {
-  const stubbedSend = sinon.stub(process, 'send');
-  const assetName = 'abc';
-  const tmpFileName = 'asdf';
-  const options = {
-    uglifyJS: {
-      bunk: true,
-    },
-  };
-
-  messageHandler({
-    type: 'minify',
-    assetName,
-    tmpFileName,
-    options,
-  });
-
-  t.true(stubbedUpdate.calledWith(tmpFileName, JSON.stringify(minifiedContent)));
-  const cacheKey = cache.createCacheKey(
-    codeSource + false,
-    options
-  );
-  t.true(stubbedSend.calledWith({
-    assetName,
-    type: 'success',
-    cacheKey,
-  }));
-  stubbedSend.restore();
 });


### PR DESCRIPTION
Worker-farm provides a cleaner abstraction around managing child processes,
allowing us to call functions instead of manually passing messages.  This api
allows us to write less code, and the code that we do write is a bit cleaner.

Sadly some of the tests were removed as part of this refactor, but coverage
will be restored in the future.