### PR TITLE
[Config] Add support for test/include/exclude.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ import ParallelUglifyPlugin from 'webpack-parallel-uglify-plugin';
 module.exports = {
   plugins: [
     new ParallelUglifyPlugin({
+      // Optional regex, or array of regex to match file against. Only matching files get minified.
+      // Defaults to /.js$/, any file ending in .js.
+      test,
+      include, // Optional regex, or array of regex to include in minification. Only matching files get minified.
+      exclude, // Optional regex, or array of regex to exclude from minification. Matching files are not minified.
       cacheDir, // Optional absolute path to use as a cache. If not provided, caching will not be used.
       workerCount, // Optional int. Number of workers to run uglify. Defaults to num of cpus - 1 or asset count (whichever is smaller)
       uglifyJS: {

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -5,6 +5,7 @@ const mkdirp = require('mkdirp');
 const webpackSources = require('webpack-sources');
 const workerFarm = require('worker-farm');
 const pify = require('pify');
+const ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
 
 const SourceMapSource = webpackSources.SourceMapSource;
 const RawSource = webpackSources.RawSource;
@@ -33,7 +34,10 @@ function processAssets(compilation, options) {
   const optionsWithoutCacheDir = Object.assign({}, options);
   optionsWithoutCacheDir.cacheDir = undefined;
 
-  const assets = Object.keys(assetHash).filter(assetName => /\.js$/.test(assetName));
+  // By default the `test` config should match every file ending in .js
+  options.test = options.test || /\.js$/i; // eslint-disable-line no-param-reassign
+  const assets = Object.keys(assetHash)
+    .filter(ModuleFilenameHelpers.matchObject.bind(null, options));
 
   // For assets that are cached, we read from the cache here rather than doing so in the worker.
   // This is a relatively fast operation, so this lets us avoid creating several workers in cases
@@ -102,7 +106,6 @@ function processAssets(compilation, options) {
     cache.pruneCache(usedCacheKeys, cache.getCacheKeysFromDisk(options.cacheDir), options.cacheDir);
     workerFarm.end(farm); // at this point we're done w/ the farm, it can be killed
   }
-
   return Promise.all(minificationPromises)
     .then(performCleanUp)
     .catch(performCleanUp);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "eslint-plugin-jsx-a11y": "^1.2.2",
     "eslint-plugin-react": "^5.1.1",
     "nyc": "^6.6.1",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.4",
+    "webpack": "^2.6.1"
   },
   "dependencies": {
     "glob": "^7.0.5",
@@ -37,5 +38,8 @@
     "uglify-js": "^2.6.2",
     "webpack-sources": "^0.1.2",
     "worker-farm": "^1.3.1"
+  },
+  "peerDependencies": {
+    "webpack": "*"
   }
 }

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -8,16 +8,28 @@ const {
 } = require('../../lib/uglifier');
 
 const filename = 'somefile.js';
-const fakeCompilationObject = {
-  assets: {
-    [filename]: {
-      source() {
-        return 'function    name()   {   }';
+const testedFilename = 'testedFilename.js';
+
+const unminifedSource = 'function    name()   {   }';
+const minifiedSource = 'function name(){}';
+
+function createFakeCompilationObject() {
+  return {
+    assets: {
+      [filename]: {
+        source() {
+          return unminifedSource;
+        },
+      },
+      [testedFilename]: {
+        source() {
+          return unminifedSource;
+        },
       },
     },
-  },
-  options: {},
-};
+    options: {},
+  };
+}
 
 test('workerCount should be cpus - 1 if assetCount is >= cpus', t => {
   const cpuStub = sinon.stub(os, 'cpus', () => ({ length: 8 }));
@@ -34,9 +46,49 @@ test('workerCount should be assetCount if assetCount is < cpus', t => {
 });
 
 test.cb('processAssets minifies each of the assets in the compilation object', (t) => {
+  const fakeCompilationObject = createFakeCompilationObject();
   processAssets(fakeCompilationObject, {}).then(() => {
-    const minifiedSource = fakeCompilationObject.assets[filename].source();
-    t.is(minifiedSource, 'function name(){}');
+    const minifiedResult = fakeCompilationObject.assets[filename].source();
+    t.is(minifiedResult, minifiedSource);
+    t.end();
+  });
+});
+
+test.cb('processAssets respects test option', (t) => {
+  const fakeCompilationObject = createFakeCompilationObject();
+  processAssets(fakeCompilationObject, {
+    test: /tested/,
+  }).then(() => {
+    const unmatchedResult = fakeCompilationObject.assets[filename].source();
+    const matchedResult = fakeCompilationObject.assets[testedFilename].source();
+    t.is(unmatchedResult, unminifedSource);
+    t.is(matchedResult, minifiedSource);
+    t.end();
+  });
+});
+
+test.cb('processAssets respects include option', (t) => {
+  const fakeCompilationObject = createFakeCompilationObject();
+  processAssets(fakeCompilationObject, {
+    include: [/tested/],
+  }).then(() => {
+    const unmatchedResult = fakeCompilationObject.assets[filename].source();
+    const matchedResult = fakeCompilationObject.assets[testedFilename].source();
+    t.is(unmatchedResult, unminifedSource);
+    t.is(matchedResult, minifiedSource);
+    t.end();
+  });
+});
+
+test.cb('processAssets respects exclude option', (t) => {
+  const fakeCompilationObject = createFakeCompilationObject();
+  processAssets(fakeCompilationObject, {
+    exclude: [/tested/],
+  }).then(() => {
+    const unmatchedResult = fakeCompilationObject.assets[filename].source();
+    const matchedResult = fakeCompilationObject.assets[testedFilename].source();
+    t.is(unmatchedResult, minifiedSource);
+    t.is(matchedResult, unminifedSource);
     t.end();
   });
 });


### PR DESCRIPTION
This commit adds support for the test/include/exclude options that are fairly
standard across Webpack plugins. This uses a utility method from Webpack to
ensure correctness.