### PR TITLE
Update webpack devDependency to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-react": "^5.1.1",
     "nyc": "^6.6.1",
     "sinon": "^1.17.4",
-    "webpack": "^2.6.1"
+    "webpack": "^3.0.0"
   },
   "dependencies": {
     "glob": "^7.0.5",


### PR DESCRIPTION
Now that 3.0.0 has been released, we should probably
be using that. I'm not sure if any other changes are required.