### PR TITLE
[Breaking] Updates to uglify v3.

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -10,15 +10,19 @@ function minify(source, map, uglifyOptions) {
   // inSourceMap doesn't work without outSourceMap, and uglify adds this as a url to the resulting
   // code. We'd rather have the plugin respect our devtool setting, so we're going to provide a
   // bogus filename, then strip it out after.
-  const opts = Object.assign({}, uglifyOptions, { fromString: true });
+  const opts = Object.assign({}, uglifyOptions);
   if (map) {
     Object.assign(opts, {
-      inSourceMap: map,
-      outSourceMap: BOGUS_SOURCEMAP_STRING,
+      sourceMap: {
+        content: map,
+        url: BOGUS_SOURCEMAP_STRING,
+      },
     });
   }
   const result = uglify.minify(source, opts);
+  if (result.error) throw result.error;
   result.code = result.code.replace(new RegExp(BOGUS_SOURCEMAP_URL), '');
+
   return result;
 }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mkdirp": "^0.5.1",
     "pify": "^3.0.0",
     "tmp": "0.0.29",
-    "uglify-js": "^2.6.2",
+    "uglify-js": "^3.0.21",
     "webpack-sources": "^1.0.0",
     "worker-farm": "^1.3.1"
   },

--- a/test/lib/worker.js
+++ b/test/lib/worker.js
@@ -10,16 +10,14 @@ const rawSource = new RawSource(codeSource);
 const originalSource = new OriginalSource(codeSource);
 const sourceAndMap = rawSource.sourceAndMap();
 const options = {
-  uglifyJS: {
-    bunk: true,
-  },
+  uglifyJS: { },
 };
 const originalContent = JSON.stringify({
   source: sourceAndMap.source,
   map: sourceAndMap.map,
   options,
 });
-const minifiedContent = uglify.minify(codeSource, { fromString: true });
+const minifiedContent = uglify.minify(codeSource, { });
 
 // ava is multi process and uses process.on,
 // so we stub it to be sure it doesn't get in the way.
@@ -44,7 +42,7 @@ test.afterEach(() => {
 test('minify should not return a map if called with a RawSource object', t => {
   const { map } = rawSource.sourceAndMap();
   const result = minify(codeSource, map);
-  t.is(result.map, null);
+  t.is(result.map, undefined);
   t.is(result.code, minifiedContent.code); // should produce the same minified content.
 });
 


### PR DESCRIPTION
This is a breaking change as we allow our users to directly pass options to
uglify, and those options have changed in uglify v3.  Updating to uglify v3
paves the way for enabling optional es6 support, as uglify-es shares the same
api as uglify v3.