### PR TITLE
Use the option workerCount

### DIFF
--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -15,7 +15,10 @@ const tmpFile = require('./tmp-file');
  * Determines how many workers to create.
  * Should be available cpus minus 1 or the number of assets to minify, whichever is smaller.
  */
-function workerCount(assetCount) {
+function workerCount(options, assetCount) {
+  if (options.workerCount) {
+    return options.workerCount;
+  }
   return Math.min(assetCount, Math.max(1, os.cpus().length - 1));
 }
 
@@ -68,7 +71,7 @@ function processAssets(compilation, options) {
   const farm = workerFarm({
     autoStart: true,
     maxConcurrentCallsPerWorker: 1,
-    maxConcurrentWorkers: workerCount(uncachedAssets.length),
+    maxConcurrentWorkers: workerCount(options, uncachedAssets.length),
     maxRetries: 2, // Allow for a couple of transient errors.
   },
    require.resolve('./worker'),

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -49,14 +49,34 @@ function createFakeCompilationObject() {
 test('workerCount should be cpus - 1 if assetCount is >= cpus', t => {
   const cpuStub = sinon.stub(os, 'cpus', () => ({ length: 8 }));
   const assetCount = 10;
-  t.is(workerCount(assetCount), 7);
+  const options = {};
+  t.is(workerCount(options, assetCount), 7);
   cpuStub.restore();
 });
 
 test('workerCount should be assetCount if assetCount is < cpus', t => {
   const cpuStub = sinon.stub(os, 'cpus', () => ({ length: 8 }));
   const assetCount = 5;
-  t.is(workerCount(assetCount), 5);
+  const options = {};
+  t.is(workerCount(options, assetCount), 5);
+  cpuStub.restore();
+});
+
+test('workerCount should follow options', t => {
+  const assetCount = 5;
+  const options = {
+    workerCount: 2,
+  };
+  t.is(workerCount(options, assetCount), 2);
+});
+
+test('workerCount should take options before checking assets or cpu', t => {
+  const cpuStub = sinon.stub(os, 'cpus', () => ({ length: 2 }));
+  const assetCount = 2;
+  const options = {
+    workerCount: 4,
+  };
+  t.is(workerCount(options, assetCount), 4);
   cpuStub.restore();
 });
 


### PR DESCRIPTION
The option workerCount is currently ignored.

This should stop it from starting more workers then allowed. But if provided always go for the option provided.

I hope I not totally misunderstood how things work.