### PR TITLE
Fix source map test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   "author": "Gary Borton <gdborton@gmail.com>",
   "license": "ISC",
   "devDependencies": {
+    "acorn": "^5.1.1",
     "ava": "^0.15.1",
     "coveralls": "^2.11.9",
+    "escodegen": "^1.8.1",
     "eslint": "^2.10.2",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.8.0",


### PR DESCRIPTION
The tests for source map support were failing silently, this corrects that.

**[tests] Add tests to check that the compilation object is updated with errors.**
I noticed that the sourcemap test was passing when it should not have been.
That test needs to be corrected, but this additional test would have surfaced
the build error easier.

**[tests] Correct failing sourceMap tests.**
These were previously failing due to the provided SourceMap being a string and
not an object as webpack would pass. This update also introduces acorn and
escodegen, which are used together to create an input sourceMap rather than
creating one by hand.
