### PR TITLE
Add uglify es support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,26 @@
 const uglifier = require('./lib/uglifier');
 
+function sourceMapError(lib) {
+  return `You should not pass options.${lib}.sourceMap, did you mean options.sourceMap?`;
+}
+
 function FasterUglifyPlugin(options) {
+  if (options.uglifyJS && options.uglifyES) {
+    throw new TypeError('You cannot use both uglifyJS and uglifyES for the same plugin.');
+  }
+
+  if (options.uglifyJS && options.uglifyJS.sourceMap) {
+    throw new TypeError(sourceMapError('uglifyJS'));
+  }
+
+  if (options.uglifyES && options.uglifyES.sourceMap) {
+    throw new TypeError(sourceMapError('uglifyES'));
+  }
   this.options = options;
+
+  if (!(this.options.uglifyJS || this.options.uglifyES)) {
+    this.options.uglifyJS = {};
+  }
 }
 
 FasterUglifyPlugin.prototype.apply = function apply(compiler) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,4 +1,3 @@
-const uglify = require('uglify-js');
 const cache = require('./cache');
 const tmpFile = require('./tmp-file');
 const BOGUS_SOURCEMAP_STRING = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -6,7 +5,7 @@ const BOGUS_SOURCEMAP_STRING = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const URL_PREFIX = '//# sourceMappingURL=';
 const BOGUS_SOURCEMAP_URL = `\n${URL_PREFIX}${BOGUS_SOURCEMAP_STRING}`;
 
-function minify(source, map, uglifyOptions) {
+function minify(source, map, uglifyOptions, uglifier) {
   // inSourceMap doesn't work without outSourceMap, and uglify adds this as a url to the resulting
   // code. We'd rather have the plugin respect our devtool setting, so we're going to provide a
   // bogus filename, then strip it out after.
@@ -19,7 +18,8 @@ function minify(source, map, uglifyOptions) {
       },
     });
   }
-  const result = uglify.minify(source, opts);
+
+  const result = uglifier.minify(source, opts);
   if (result.error) throw result.error;
   result.code = result.code.replace(new RegExp(BOGUS_SOURCEMAP_URL), '');
 
@@ -53,7 +53,8 @@ function processMessage(msgLocation, callback) {
     const cacheKey = cache.createCacheKey(source + !!map, message.options);
     // We do not check the cache here because we already determined that this asset yields a cache
     // miss in the parent process.
-    const minifiedContent = minify(source, map, message.options.uglifyJS);
+    const uglifier = message.options.uglifyES ? require('uglify-es') : require('uglify-js'); // eslint-disable-line global-require, max-len
+    const minifiedContent = minify(source, map, message.options.uglifyJS, uglifier);
     cache.saveToCache(cacheKey, JSON.stringify({
       source: minifiedContent.code,
       map: minifiedContent.map,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mkdirp": "^0.5.1",
     "pify": "^3.0.0",
     "tmp": "0.0.29",
+    "uglify-es": "^3.0.26",
     "uglify-js": "^3.0.21",
     "webpack-sources": "^1.0.0",
     "worker-farm": "^1.3.1"

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,31 @@
+/* eslint no-new:0 */
+import test from 'ava';
+import WebpackParallelUglifyPlugin from '../index';
+
+test('creating a WebpackParallelUglifyPlugin instance w/ both uglify options throws', (t) => {
+  t.throws(() => {
+    new WebpackParallelUglifyPlugin({
+      uglifyJS: {},
+      uglifyES: {},
+    });
+  });
+});
+
+test('creating a WebpackParallelUglifyPlugin instance with uglify.sourceMap throws', (t) => {
+  t.throws(() => {
+    new WebpackParallelUglifyPlugin({
+      uglifyJS: { sourceMap: true },
+    });
+  });
+
+  t.throws(() => {
+    new WebpackParallelUglifyPlugin({
+      uglifyES: { sourceMap: true },
+    });
+  });
+});
+
+test('providing no uglify options defaults to uglifyJS: {}', (t) => {
+  const plugin = new WebpackParallelUglifyPlugin({});
+  t.deepEqual(plugin.options, { uglifyJS: {} });
+});

--- a/test/lib/uglifer.js
+++ b/test/lib/uglifer.js
@@ -58,6 +58,23 @@ function createFakeCompilationObject() {
   };
 }
 
+function createFakeES6CompilationObject() {
+  return {
+    assets: {
+      'someFile.js': {
+        source() {
+          return '() => {}';
+        },
+        map() {
+          return null;
+        },
+      },
+    },
+    options: {},
+    errors: [],
+  };
+}
+
 function assertNoError(compilationObject, t) {
   t.is(compilationObject.errors.length, 0);
 }
@@ -202,5 +219,25 @@ test('invalid JS should generate an error', (t) => {
     uglifyJS: {},
   }).then(() => {
     t.truthy(errorCompilationObject.errors[0].message.includes(realErrorMessage));
+  });
+});
+
+test('Passing uglifyJS options throws an error when minifying es6', (t) => {
+  const es6CompilationObject = createFakeES6CompilationObject();
+  return processAssets(es6CompilationObject, {
+    sourceMap: false,
+    uglifyJS: {},
+  }).then(() => {
+    t.is(es6CompilationObject.errors.length, 1);
+  });
+});
+
+test('Passing uglifyES options does not throw an error when minifying es6', (t) => {
+  const es6CompilationObject = createFakeES6CompilationObject();
+  return processAssets(es6CompilationObject, {
+    sourceMap: false,
+    uglifyES: {},
+  }).then(() => {
+    assertNoError(es6CompilationObject, t);
   });
 });

--- a/test/lib/worker.js
+++ b/test/lib/worker.js
@@ -41,14 +41,14 @@ test.afterEach(() => {
 
 test('minify should not return a map if called with a RawSource object', t => {
   const { map } = rawSource.sourceAndMap();
-  const result = minify(codeSource, map);
+  const result = minify(codeSource, map, undefined, uglify);
   t.is(result.map, undefined);
   t.is(result.code, minifiedContent.code); // should produce the same minified content.
 });
 
 test('minify should return a valid source map if called with an OriginalSource object', t => {
   const { map } = originalSource.sourceAndMap();
-  const result = minify(codeSource, map);
+  const result = minify(codeSource, map, undefined, uglify);
   t.truthy(result.map);
   t.is(result.code, minifiedContent.code); // should produce the same minified content.
 });


### PR DESCRIPTION
uglify-es is a branch of uglify-js that is meant to enable uglifying of es6
code. This commit enables the newer uglify if the user provides uglifyES
options to the plugin.  I chose to support both since not everyone needs to
support older browsers, but those that do would likely appreciate if the tool
catches any sneaky es6.