### PR TITLE
expose the workder-farm config outside

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 npm-debug.log
 coverage
 .nyc_output
+
+yarn.lock

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -39,14 +39,28 @@ function processAssets(compilation, options) {
 
   // By default the `test` config should match every file ending in .js
   options.test = options.test || /\.js$/i; // eslint-disable-line no-param-reassign
-  const assets = Object.keys(assetHash)
-    .filter(ModuleFilenameHelpers.matchObject.bind(null, options));
 
   // For assets that are cached, we read from the cache here rather than doing so in the worker.
   // This is a relatively fast operation, so this lets us avoid creating several workers in cases
   // when we have a near 100% cache hit rate.
   const cacheKeysOnDisk = new Set(cache.getCacheKeysFromDisk(options.cacheDir));
   const uncachedAssets = [];
+
+  const defaultWorkerFarmOptions = {
+    autoStart: true,
+    maxConcurrentCallsPerWorker: 1,
+    maxConcurrentWorkers: workerCount(options, uncachedAssets.length),
+    maxRetries: 2, // Allow for a couple of transient errors.
+  };
+
+  options.workerFarm = Object.assign( // eslint-disable-line no-param-reassign
+    {},
+    defaultWorkerFarmOptions,
+    options.workerFarm
+  );
+
+  const assets = Object.keys(assetHash)
+    .filter(ModuleFilenameHelpers.matchObject.bind(null, options));
 
   assets.forEach((assetName) => {
     // sourceAndMap() is an expensive function, so we'll create the cache key from just source(),
@@ -67,12 +81,7 @@ function processAssets(compilation, options) {
       uncachedAssets.push(assetName);
     }
   });
-  options.workerFarm = options.workerFarm || {
-    autoStart: true,
-    maxConcurrentCallsPerWorker: 1,
-    maxConcurrentWorkers: workerCount(options, uncachedAssets.length),
-    maxRetries: 2, // Allow for a couple of transient errors.
-  }
+
   const farm = workerFarm(
     options.workerFarm,
     require.resolve('./worker'),

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -67,15 +67,16 @@ function processAssets(compilation, options) {
       uncachedAssets.push(assetName);
     }
   });
-
-  const farm = workerFarm({
+  options.workerFarm = options.workerFarm || {
     autoStart: true,
     maxConcurrentCallsPerWorker: 1,
     maxConcurrentWorkers: workerCount(options, uncachedAssets.length),
     maxRetries: 2, // Allow for a couple of transient errors.
-  },
-   require.resolve('./worker'),
-   ['processMessage']
+  }
+  const farm = workerFarm(
+    options.workerFarm,
+    require.resolve('./worker'),
+    ['processMessage']
   );
 
   const minify = pify(farm.processMessage);


### PR DESCRIPTION
node: v6.9.1
npm: v5.3.0

Sometimes got the `ProcessTerminatedError` error when compressing.The reason seems you hardcode the **maxRetries** in the worker-farm module's config.When I change it to Infinity, the error is solved. So I change the code and could config the workder-farm configuration at the outermost.

This PR is working in progress, also I want to listen to other people's advice.