### PR TITLE
Don't prune the cache while unoptimized assets exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ FasterUglifyPlugin.prototype.apply = function apply(compiler) {
       });
     });
   });
+
+  compiler.plugin('done', () => {
+    uglifier.pruneCache(this.options);
+  });
 };
 
 module.exports = FasterUglifyPlugin;

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -105,16 +105,21 @@ function processAssets(compilation, options) {
       });
   });
 
-  function performCleanUp() {
-    cache.pruneCache(usedCacheKeys, cache.getCacheKeysFromDisk(options.cacheDir), options.cacheDir);
+  function endWorkers() {
     workerFarm.end(farm); // at this point we're done w/ the farm, it can be killed
   }
+
   return Promise.all(minificationPromises)
-    .then(performCleanUp)
-    .catch(performCleanUp);
+    .then(endWorkers)
+    .catch(endWorkers);
+}
+
+function pruneCache(options) {
+  cache.pruneCache(usedCacheKeys, cache.getCacheKeysFromDisk(options.cacheDir), options.cacheDir);
 }
 
 module.exports = {
   processAssets,
+  pruneCache,
   workerCount,
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,19 @@
 /* eslint no-new:0 */
+import fs from 'fs';
+import glob from 'glob';
+import sinon from 'sinon';
 import test from 'ava';
 import WebpackParallelUglifyPlugin from '../index';
+
+let sandbox;
+
+test.beforeEach(() => {
+  sandbox = sinon.sandbox.create();
+});
+
+test.afterEach(() => {
+  sandbox.restore();
+});
 
 test('creating a WebpackParallelUglifyPlugin instance w/ both uglify options throws', (t) => {
   t.throws(() => {
@@ -28,4 +41,55 @@ test('creating a WebpackParallelUglifyPlugin instance with uglify.sourceMap thro
 test('providing no uglify options defaults to uglifyJS: {}', (t) => {
   const plugin = new WebpackParallelUglifyPlugin({});
   t.deepEqual(plugin.options, { uglifyJS: {} });
+});
+
+function FakeCompiler() {
+  const callbacks = {};
+  this.assets = [];
+
+  this.plugin = (event, callback) => {
+    callbacks[event] = callback;
+  };
+
+  this.fireEvent = (event, ...args) => {
+    callbacks[event].apply(this, args);
+  };
+}
+
+test('deleting unused cache files after all asset optimizations', (t) => {
+  const originalRead = fs.readFileSync;
+  sandbox.stub(fs, 'unlinkSync');
+  sandbox.stub(fs, 'writeFileSync');
+  sandbox.stub(fs, 'mkdirSync');
+  sandbox.stub(fs, 'readFileSync', (filePath, encoding) => (
+    filePath.match(/fake_cache_dir/)
+      ? 'filecontents'
+      : originalRead(filePath, encoding)
+  ));
+
+  sandbox.stub(glob, 'sync').returns(
+    [
+      '/fake_cache_dir/file1.js',
+      '/fake_cache_dir/file2.js',
+    ]
+  );
+
+  const uglifyPlugin = new WebpackParallelUglifyPlugin({
+    uglifyJS: {},
+    cacheDir: '/fake_cache_dir/',
+  });
+
+  const compiler = new FakeCompiler();
+  uglifyPlugin.apply(compiler);
+  compiler.fireEvent('compilation', compiler);
+  compiler.fireEvent('optimize-chunk-assets', null, () => {});
+  compiler.fireEvent('optimize-chunk-assets', null, () => {});
+  t.is(fs.unlinkSync.callCount, 0, 'Cache should not be cleared by optimize-chunk-assets');
+
+  compiler.fireEvent('done');
+  t.deepEqual(
+    fs.unlinkSync.args,
+    [['/fake_cache_dir/file1.js'], ['/fake_cache_dir/file2.js']],
+    'Unused cache files should be removed after compilation'
+  );
 });


### PR DESCRIPTION
Plugins like [`extract-text-webpack-plugin`](https://github.com/webpack-contrib/extract-text-webpack-plugin) may cause multiple `optimize-chunk-assets` callbacks.  This means that the uglify cache is often deleted before webpack gets around to uglifying actual JS chunks :/

Waiting for the `done` event guarantees that all chunks are processed before pruning the cache.