### PR TITLE
Pretty syntax errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 coverage
 .nyc_output
+package-lock.json

--- a/lib/uglifier.js
+++ b/lib/uglifier.js
@@ -101,7 +101,8 @@ function processAssets(compilation, options) {
         }
       })
       .catch((e) => {
-        compilation.errors.push(new Error(`minifying ${assetName}\n${e}`));
+        const builtError = new Error(`Encountered an error while minifying ${assetName}:\n${e}`);
+        compilation.errors.push(builtError);
       });
   });
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,3 +1,4 @@
+const codeFrame = require('babel-code-frame');
 const cache = require('./cache');
 const tmpFile = require('./tmp-file');
 const BOGUS_SOURCEMAP_STRING = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -20,7 +21,16 @@ function minify(source, map, uglifyOptions, uglifier) {
   }
 
   const result = uglifier.minify(source, opts);
-  if (result.error) throw result.error;
+  if (result.error) {
+    if (result.error.name === 'SyntaxError') {
+      const frame = codeFrame(source, result.error.line, result.error.col);
+      const errorMessage = `${result.error.name}: ${result.error.message}\n${frame}`;
+      throw new SyntaxError(errorMessage);
+    }
+
+    throw result.error;
+  }
+
   result.code = result.code.replace(new RegExp(BOGUS_SOURCEMAP_URL), '');
 
   return result;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "webpack": "^3.0.0"
   },
   "dependencies": {
+    "babel-code-frame": "^6.26.0",
     "glob": "^7.0.5",
     "mkdirp": "^0.5.1",
     "pify": "^3.0.0",


### PR DESCRIPTION
A developer on my team spent more time than needed debugging a SyntaxError
that was the result of attempting to minify es6 code that snuck into
node_modules/. I think that by providing additional context on the failed file,
we can help people be more productive.

This change uses babel-code-frame to generate an error message that includes a
few lines above/below the encountered SyntaxError.