### PR TITLE
Bump uglify-js and uglify-es versions to fix Uglify bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "mkdirp": "^0.5.1",
     "pify": "^3.0.0",
     "tmp": "0.0.29",
-    "uglify-es": "^3.0.26",
-    "uglify-js": "^3.0.21",
+    "uglify-es": "^3.3.9",
+    "uglify-js": "^3.6.0",
     "webpack-sources": "^1.0.0",
     "worker-farm": "^1.3.1"
   },


### PR DESCRIPTION
We need to bump the version of `uglify_js` in this package in order to fix a bug with UglifyJS when the `reduce_funcs` compress option is used.

Any version below `~3.4` produces the following minified code for https://github.com/paulmillr/es6-shim/blob/master/es6-shim.js when `-c reduce_funcs=false`:

```
var r,
  n = function(t, e) {
    if (!lt.TypeIsObject(t) || !hM._es6map)
      throw new TypeError(
        'Method Map.prototype.' + e + ' called on incompatible receiver ' + lt.ToString(t),
      );
  };
```

`hM` here is an invalid reference.

The latest version, `3.6.0`, produces the following code:

```
var r,
  n = function(t, e) {
    if (
      !ct.TypeIsObject(t) ||
      !(function(t) {
        return !!t._es6map;
      })(t)
    )
      throw new TypeError(
        'Method Map.prototype.' + e + ' called on incompatible receiver ' + ct.ToString(t),
      );
  };
```

This code is valid.